### PR TITLE
無邪気にアクセスすると{"detail":"Not Found"}

### DIFF
--- a/qrgen/api.py
+++ b/qrgen/api.py
@@ -1,7 +1,7 @@
 import io
 import functools
 from logging import getLogger
-from fastapi import FastAPI, Query
+from fastapi import FastAPI, Query, Request
 from fastapi.responses import Response, HTMLResponse, PlainTextResponse, RedirectResponse
 from enum import Enum
 from qrcode.main import QRCode
@@ -190,7 +190,10 @@ class WifiType(str, Enum):
 
 
 @api.get("/")
-def do_doc():
+def do_doc(request: Request):
+    root = request.scope.get("root_path")
+    if root:
+        return RedirectResponse(urllib.parse.urljoin(root, "docs"))
     return RedirectResponse("/docs")
 
 

--- a/qrgen/api.py
+++ b/qrgen/api.py
@@ -191,10 +191,7 @@ class WifiType(str, Enum):
 
 @api.get("/")
 def do_doc(request: Request):
-    root = request.scope.get("root_path")
-    if root:
-        return RedirectResponse(urllib.parse.urljoin(root, "docs"))
-    return RedirectResponse("/docs")
+    return RedirectResponse(urllib.parse.urljoin(str(request.url), "docs"))
 
 
 @api.get("/wifi")

--- a/qrgen/api.py
+++ b/qrgen/api.py
@@ -2,7 +2,7 @@ import io
 import functools
 from logging import getLogger
 from fastapi import FastAPI, Query
-from fastapi.responses import Response, HTMLResponse, PlainTextResponse
+from fastapi.responses import Response, HTMLResponse, PlainTextResponse, RedirectResponse
 from enum import Enum
 from qrcode.main import QRCode
 import urllib.parse
@@ -187,6 +187,11 @@ class WifiType(str, Enum):
     wpa = "WPA"
     wpa2_eap = "WPA2-EAP"
     nopass = "nopass"
+
+
+@api.get("/")
+def do_doc():
+    return RedirectResponse("/docs")
 
 
 @api.get("/wifi")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -33,3 +33,8 @@ class TestAPI(unittest.TestCase):
         res = self.client.get("/wifi", params={"ssid": "SSID123"})
         self.assertEqual(200, res.status_code)
         self.assertEqual("image/png", res.headers.get("Content-Type"))
+
+    def test_root(self):
+        res = self.client.get("/", follow_redirects=False)
+        self.assertTrue(res.is_redirect)
+        self.assertEqual("/docs", res.headers.get("location"))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -37,4 +37,4 @@ class TestAPI(unittest.TestCase):
     def test_root(self):
         res = self.client.get("/", follow_redirects=False)
         self.assertTrue(res.is_redirect)
-        self.assertEqual("/docs", res.headers.get("location"))
+        self.assertTrue(res.headers.get("location").endswith("/docs"))


### PR DESCRIPTION
`GET /` は /docsにリダイレクトしてもいいんじゃないかと